### PR TITLE
Add a way to load shader into cache from file

### DIFF
--- a/src/glow/GlShaderCache.cpp
+++ b/src/glow/GlShaderCache.cpp
@@ -1,6 +1,7 @@
 #include "GlShaderCache.h"
 
 #include <iostream>
+#include <fstream>
 
 namespace glow {
 
@@ -20,6 +21,24 @@ std::string GlShaderCache::getSource(const std::string& filename) {
   std::string b = basename(filename);
 
   return sources_[b];
+}
+
+void GlShaderCache::insertSource(const std::string& filename) {
+  std::ios::openmode mode = std::ios::in | std::ios::ate;
+  std::ifstream ifs(filename, mode);
+  std::string source;
+  if (ifs) {
+    const std::streamsize size = static_cast<const std::streamsize>(ifs.tellg());
+    ifs.seekg(0, std::ios::beg);
+    source.resize(size);
+    ifs.read(const_cast<char*>(source.data()), size);
+    source.resize(ifs.gcount());
+    ifs.close();
+  } else {
+    std::cerr << "Error: Reading from file '" << filename << "' failed." << std::endl;
+    source = "";
+  }
+  insertSource(filename, source);
 }
 
 void GlShaderCache::insertSource(const std::string& filename, const std::string& source) {

--- a/src/glow/GlShaderCache.h
+++ b/src/glow/GlShaderCache.h
@@ -29,6 +29,8 @@ class GlShaderCache {
 
   /** \brief add source for given cache key value. **/
   void insertSource(const std::string& filename, const std::string& source);
+  /** \brief read and add source from a file **/
+  void insertSource(const std::string& filename);
 
  protected:
   GlShaderCache();


### PR DESCRIPTION
This seems to be pretty useful while writing initial code without generating binary cache.