### PR TITLE
Fix warnings on modern g++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ else()
   set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -O3 -DNDEBUG ${CMAKE_CXX_FLAGS}")
 endif()
 
-message("Using CMAKE_CXX_FLAGS = ${CMAKE_CXX_FLAGS}")
+message(STATUS "Using CMAKE_CXX_FLAGS = ${CMAKE_CXX_FLAGS}")
 
 option(ENABLE_NVIDIA_EXT "Enable Nvidia GL capabilites." OFF)
 set(OPENGL_VERSION 330 CACHE STRING "Available OpenGL version")

--- a/test/buffer-test.cpp
+++ b/test/buffer-test.cpp
@@ -30,8 +30,8 @@ TEST(BufferTest, assignTest) {
 
   ASSERT_EQ(BufferTarget::ARRAY_BUFFER, buffer.target());
   ASSERT_EQ(BufferUsage::DYNAMIC_DRAW, buffer.usage());
-  ASSERT_EQ(0, buffer.size());      // empty buffer.
-  ASSERT_EQ(0, buffer.capacity());  // really empty buffer.
+  ASSERT_EQ(static_cast<size_t>(0), buffer.size());      // empty buffer.
+  ASSERT_EQ(static_cast<size_t>(0), buffer.capacity());  // really empty buffer.
 
   buffer.assign(values);
   ASSERT_EQ(values.size(), buffer.size());  // now not empty buffer.
@@ -63,8 +63,8 @@ TEST(BufferTest, reserveTest) {
   GlBuffer<float> buffer(BufferTarget::ARRAY_BUFFER, BufferUsage::DYNAMIC_DRAW);
 
   buffer.reserve(1000);
-  ASSERT_EQ(1000, buffer.capacity());
-  ASSERT_EQ(0, buffer.size());
+  ASSERT_EQ(static_cast<size_t>(1000), buffer.capacity());
+  ASSERT_EQ(static_cast<size_t>(0), buffer.size());
 
   ASSERT_NO_THROW(CheckGlError());
 }
@@ -73,17 +73,17 @@ TEST(BufferTest, resizeTest) {
   GlBuffer<float> buffer(BufferTarget::ARRAY_BUFFER, BufferUsage::DYNAMIC_DRAW);
 
   buffer.reserve(1000);
-  ASSERT_EQ(1000, buffer.capacity());
-  ASSERT_EQ(0, buffer.size());
+  ASSERT_EQ(static_cast<size_t>(1000), buffer.capacity());
+  ASSERT_EQ(static_cast<size_t>(0), buffer.size());
 
   buffer.resize(123);
-  ASSERT_EQ(123, buffer.size());
-  ASSERT_EQ(1000, buffer.capacity());
+  ASSERT_EQ(static_cast<size_t>(123), buffer.size());
+  ASSERT_EQ(static_cast<size_t>(1000), buffer.capacity());
 
   GlBuffer<float> buffer2(BufferTarget::ARRAY_BUFFER, BufferUsage::DYNAMIC_DRAW);
   buffer2.resize(145);
-  ASSERT_EQ(145, buffer2.size());
-  ASSERT_EQ(145, buffer2.capacity());
+  ASSERT_EQ(static_cast<size_t>(145), buffer2.size());
+  ASSERT_EQ(static_cast<size_t>(145), buffer2.capacity());
 
   ASSERT_NO_THROW(CheckGlError());
 }

--- a/test/texture-test.cpp
+++ b/test/texture-test.cpp
@@ -17,7 +17,7 @@ TEST(TextureTest, assignTest) {
   GlTexture texture(100, 50, TextureFormat::RGBA_FLOAT);
   ASSERT_NO_THROW(CheckGlError());
   std::vector<float> img(100 * 50 * 4);
-  ASSERT_EQ(100 * 50 * 4, img.size());
+  ASSERT_EQ(static_cast<size_t>(100 * 50 * 4), img.size());
   for (uint32_t i = 0; i < img.size(); ++i) {
     img[i] = 1.45f * i;
   }
@@ -110,7 +110,7 @@ TEST(TextureRectangleTest, assignTest) {
   GlTextureRectangle texture(100, 50, TextureFormat::RGBA_FLOAT);
   ASSERT_NO_THROW(CheckGlError());
   std::vector<float> img(100 * 50 * 4);
-  ASSERT_EQ(100 * 50 * 4, img.size());
+  ASSERT_EQ(static_cast<size_t>(100 * 50 * 4), img.size());
   for (uint32_t i = 0; i < img.size(); ++i) {
     img[i] = 1.45f * i;
   }


### PR DESCRIPTION
These are just cosmetic changes to avoid showing warning when compiling with `-Wall`

- add STATUS to the CMake output to avoid it breaking catkin flow
- cast all implicit ints to size_t when compared to one in tests